### PR TITLE
Remove internal gitlab name from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Usage 
 
-`$ npm install -g git@gitlab.eng.roku.com:mtaylor/rokujs.git`
+`$ npm install -g git@<rokus_internal_git_server>:mtaylor/rokujs.git`
 
 `$ js2bs -o <outDir> -i <inpDir> <file|direcory>`
 


### PR DESCRIPTION
Hi, from Roku. We would like the link scrubbed from your repo